### PR TITLE
Override rustup toolchain with stable

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -27,6 +27,7 @@ build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
   export CARGO_HOME="${srcdir}/${pkgname}/CARGO"
   export CFLAGS="-fcommon -fPIE"
+  export RUSTUP_TOOLCHAIN=stable
   cargo build --release
 }
 


### PR DESCRIPTION
It is better to specify explicitly which toolchain to use when building with cargo because
- user may override default rustup toolchain with an incompatible one
- user may isolate builds / use jails. Some AUR helpers are automating this (ie: [rua](https://github.com/vn971/rua#safety)). In such case following error may be produced and build fails: `error: no override and no default toolchain set`